### PR TITLE
Conversion - transform shorthand syntax intrinsic functions

### DIFF
--- a/intrinsicsolver/elongateForms.go
+++ b/intrinsicsolver/elongateForms.go
@@ -1,0 +1,40 @@
+package intrinsicsolver
+
+import (
+	"strings"
+)
+
+/* Function elongateForms is investigating for short-form functions and changes them for their long equivalent. */
+func elongateForms(line *string, lines *[]string, idx int, name string) {
+	var currentFunctions int
+	pLines := *lines
+	totalFunctions := strings.Count(*line, "!")
+	for (currentFunctions != totalFunctions+1) && !strings.Contains(*line, "#!/bin/bash") && strings.Contains(*line, "!") {
+		short := shortForm(name)
+		long := longForm(name)
+		full := fullForm(long)
+		split := strings.Split(*line, short)
+		if idx+1 < len(pLines) {
+			if strings.Contains(*line, name) && strings.Contains(pLines[idx+1], "-") && (len(split) != 2) {
+				// If so - we don't have to surround it with quotes.
+				if strings.Contains(*line, short) && !strings.Contains(*line, "|") {
+					*line = strings.Replace(*line, short, full, -1)
+				} else if strings.Contains(*line, short) && strings.Contains(*line, "|") {
+					*line = strings.Replace(*line, (short + " |"), full, -1)
+				}
+			} else if strings.Contains(*line, name) {
+				if strings.Contains(*line, short) && !strings.Contains(*line, "|") {
+					*line = strings.Replace(*line, short, ("\"" + long + "\":"), -1)
+				} else if strings.Contains(*line, short) && strings.Contains(*line, "|") {
+					*line = strings.Replace(*line, (short + " |"), ("\"" + long + "\":"), -1)
+				} else if strings.Contains(*line, full) && !strings.Contains(*line, "|") {
+					*line = strings.Replace(*line, full, ("\"" + long + "\":"), -1)
+				} else if strings.Contains(*line, full) && strings.Contains(*line, "|") {
+					*line = strings.Replace(*line, (full + " |"), ("\"" + long + "\":"), -1)
+				}
+			}
+		}
+		currentFunctions++
+	}
+
+}

--- a/intrinsicsolver/fixFunctions.go
+++ b/intrinsicsolver/fixFunctions.go
@@ -13,12 +13,16 @@ import (
 
 /*
 FixFunctions : takes []byte file and firstly converts all single quotation marks to double ones (anything between single ones is treated as the rune in GoLang),
-then deconstructs file into lines, checks for intrinsic functions of a map nature where the function name is located in one line and it's body (map elements)
+then deconstructs file into lines, checks for intrinsic functions. The FixFunctions has modes: `multiline`, `elongate` and `correctlong`.
+Mode `multiline` looks for functions of a map nature where the function name is located in one line and it's body (map elements)
 are located in the following lines (if this would be not fixed an error would be thrown: `json: unsupported type: map[interface {}]interface {}`).
-The function changes the notation by putting function name in the next line with proper indentation and saves the result to temporary file,
-then opens it and returns []byte array.
+The function changes the notation by putting function name in the next line with proper indentation.
+Mode `elongate` exchanges the short function names into their proper, long equivalent.
+Mode `correctlong` prepares the file for conversion into JSON. If the file is a YAML with every line being solicitously indented, there is no problem and the `elongate` mode is all we need.
+But if there is any mixed notation (e.g. indented maps along with one-line maps, functions in one line with the key), parsing must be preceded with some additional operations.
+The result is saved to temporary file, then opened and returned as a []byte array.
 */
-func FixFunctions(template []byte, logger *logger.Logger) ([]byte, error) {
+func FixFunctions(template []byte, logger *logger.Logger, mode ...string) ([]byte, error) {
 	var quotationProcessed, temporaryResult []string
 	preLines, err := parseFileIntoLines(template, logger)
 
@@ -34,33 +38,69 @@ func FixFunctions(template []byte, logger *logger.Logger) ([]byte, error) {
 		quotationProcessed = append(quotationProcessed, fixed)
 	}
 
+	// In case the intrinsic function is in the last line and the the next line is investigated in search for it's multi-line body, we have to add one, blank line.
+	quotationProcessed = append(quotationProcessed, "")
+
 	lines := quotationProcessed
 
-	// These are the YAML short names of a functions which take the arguments in a form of a map.
-	multiLiners := []string{"!FindInMap", "!Join", "!Select", "!Split", "!Sub", "!And", "!Equals", "!If", "!Not", "!Or"}
+	var functions = []string{"Base64", "GetAtt", "GetAZs", "ImportValue", "Ref", "FindInMap", "Join", "Select", "Split", "Sub", "And", "Equals", "If", "Not", "Or"}
 
 	for idx, d := range lines {
-		for _, function := range multiLiners {
-			fixMultiLineMap(&d, &lines, idx, function)
+		for _, m := range mode {
+			if m == "multiline" {
+				for _, function := range functions[5:] {
+					fixMultiLineMap(&d, &lines, idx, function)
+				}
+			}
+			if m == "elongate" {
+				for _, function := range functions {
+					elongateForms(&d, &lines, idx, function)
+				}
+			}
+			if m == "correctlong" {
+				fixLongFormCorrectness(&d)
+			}
 		}
 
 		temporaryResult = append(temporaryResult, d)
 	}
 
 	// Function writeLines saves the processed result to a file (if there would be any errors, it could be investigated there).
-	if err := writeLines(temporaryResult, "preprocessed.yml"); err != nil {
+	if err := writeLines(temporaryResult, ".preprocessed.yml"); err != nil {
 		logger.Error(err.Error())
 		return nil, err
 	}
 
 	// Then the temporary result is opened and returned as a []byte.
-	preprocessedTemplate, err := ioutil.ReadFile("preprocessed.yml")
+	preprocessedTemplate, err := ioutil.ReadFile(".preprocessed.yml")
 	if err != nil {
 		logger.Error(err.Error())
 		return preprocessedTemplate, err
 	}
 
 	return preprocessedTemplate, nil
+}
+
+// Expands the function name to it's long form without a colon. For example - Fn::FindInMap.
+func longForm(name string) string {
+	var fullName string
+	if name != "Ref" {
+		fullName = "Fn::" + name
+	} else {
+		fullName = name
+	}
+	return fullName
+}
+
+/* Expands the function name by adding a colon. For example - Fn::FindInMap:.
+It is crucial to pass here the output from the longForm function.*/
+func fullForm(name string) string {
+	return (name + ":")
+}
+
+// Expands the function name to it's short form. For example - !FindInMap.
+func shortForm(name string) string {
+	return ("!" + name)
 }
 
 // Function parseFileIntoLines is reading the []byte file and returns it line by line as []string slice.

--- a/intrinsicsolver/fixLongFormCorrectness.go
+++ b/intrinsicsolver/fixLongFormCorrectness.go
@@ -1,0 +1,18 @@
+package intrinsicsolver
+
+import (
+	"strings"
+)
+
+/* Unfortunately the short-to-long-form function names exchange isn't solving the issue of YAML being ready for the YAML-JSON conversion.
+In some cases the parser is misinterpretating function in it's long form with additional key and throws an error. We must enclose functions in curly braces. */
+func fixLongFormCorrectness(line *string) {
+	keyValue := strings.SplitAfterN(*line, ":", 2)
+	if len(keyValue) == 2 && !strings.Contains(keyValue[0], "Fn:") {
+		if strings.Contains(keyValue[1], "\"Fn::") && !strings.Contains(keyValue[0], "Fn") {
+			*line = strings.Replace(*line, keyValue[1], (" {" + keyValue[1] + "}"), 1)
+		} else if strings.Contains(keyValue[1], "\"Ref") && !strings.Contains(keyValue[0], "Ref") {
+			*line = strings.Replace(*line, keyValue[1], (" {" + keyValue[1] + "}"), 1)
+		}
+	}
+}

--- a/intrinsicsolver/fixMultiLineMap.go
+++ b/intrinsicsolver/fixMultiLineMap.go
@@ -4,23 +4,31 @@ import (
 	"strings"
 )
 
-// Function fixMultiLineMap detects if a function is of a multi-line map nature by checking what follows the function name. At the moment the goformation library is inappropriately handling the case where the function name is in the same line as the key and the body of a function isn't in the same line. There are many ways to solve this problem but the fastest is to move the function name to the next line, indent it and transform it to it's full name. Other solutions include rewriting the whole function and it's body in one line but due the lack of knowledge of how nested the map internal structure is and where it ends, this solution is not chosen.
+/* Function fixMultiLineMap detects if a function is of a multi-line map nature by checking what follows the function name.
+At the moment the goformation library is inappropriately handling the case where the function name is in the same line as the key and the body of a function isn't in the same line.
+There are many ways to solve this problem but the fastest is to move the function name to the next line, indent it and transform it to it's full name.
+Other solutions include rewriting the whole function and it's body in one line but due the lack of knowledge of how nested the map internal structure is and where it ends,
+this solution is not chosen. */
 func fixMultiLineMap(line *string, lines *[]string, idx int, name string) {
 	pLines := *lines
-	longName := "Fn::" + strings.Split(name, "!")[1] + ":"
-	if strings.Contains(*line, name) && !strings.Contains(*line, "|") {
-		split := strings.Split(*line, name)
-		if strings.Contains(pLines[idx+1], "-") && split[1] == "" {
-			// If so - we have multiple-level function with a body created of a map elements as the hyphen-noted structures.
-			if strings.Contains(*line, ":") {
-				// If so - we have key and a function name in one line. We have to relocate the function name into the next line, indent it and change it to the long form.
-				nextLineIndents := indentations(pLines[idx+1])
-				fullIndents := strings.Repeat(" ", nextLineIndents)
-				replacement := "\n" + fullIndents + longName
-				*line = strings.Replace(*line, name, replacement, -1)
-			} else {
-				// If so - we have function as the element of another map - we assume that it is well indented so we only change the form to the long one.
-				*line = strings.Replace(*line, name, longName, -1)
+	short := shortForm(name)
+	long := longForm(name)
+	full := fullForm(long)
+	if strings.Contains(*line, short) && !strings.Contains(*line, "|") {
+		split := strings.Split(*line, short)
+		if idx+1 < len(pLines) {
+			if strings.Contains(pLines[idx+1], "-") && (len(split) == 1 || split[1] == "") {
+				// If so - we have multiple-level function with a body created of a map elements as the hyphen-noted structures.
+				if strings.Contains(*line, ":") {
+					// If so - we have key and a function name in one line. We have to relocate the function name into the next line, indent it and change it to the long form.
+					nextLineIndents := indentations(pLines[idx+1])
+					fullIndents := strings.Repeat(" ", nextLineIndents)
+					replacement := "\n" + fullIndents + full
+					*line = strings.Replace(*line, short, replacement, -1)
+				} else {
+					// If so - we have function as the element of another map - we assume that it is well indented so we only change the form to the long one.
+					*line = strings.Replace(*line, short, full, -1)
+				}
 			}
 		}
 	}

--- a/intrinsicsolver/intrinsicsolver_test.go
+++ b/intrinsicsolver/intrinsicsolver_test.go
@@ -45,12 +45,44 @@ func TestIndentations(t *testing.T) {
 	assert.Equal(t, "K", firstLetter, "MSG")
 }
 
-func TestFixFunctions(t *testing.T) {
+func TestMultiline(t *testing.T) {
 	rawTemplate, _ := ioutil.ReadFile("./test_resources/test_map.yaml")
 	expectedTemplate, _ := ioutil.ReadFile("./test_resources/manual_test_map.yaml")
-	fixed, _ := FixFunctions(rawTemplate, &sink)
+	fixed, _ := FixFunctions(rawTemplate, &sink, "multiline")
 	expected, _ := parseFileIntoLines(expectedTemplate, &sink)
 	actual, _ := parseFileIntoLines(fixed, &sink)
+
+	if string(actual[len(actual)-1]) == "" {
+		actual = actual[:(len(actual) - 1)]
+	}
+
+	assert.Equal(t, expected, actual, "MSG")
+}
+
+func TestElongate(t *testing.T) {
+	rawTemplate, _ := ioutil.ReadFile("./test_resources/test_elongate.yaml")
+	expectedTemplate, _ := ioutil.ReadFile("./test_resources/manual_test_elongate.yaml")
+	fixed, _ := FixFunctions(rawTemplate, &sink, "elongate")
+	expected, _ := parseFileIntoLines(expectedTemplate, &sink)
+	actual, _ := parseFileIntoLines(fixed, &sink)
+
+	if string(actual[len(actual)-1]) == "" {
+		actual = actual[:(len(actual) - 1)]
+	}
+
+	assert.Equal(t, expected, actual, "MSG")
+}
+
+func TestCorrectLong(t *testing.T) {
+	rawTemplate, _ := ioutil.ReadFile("./test_resources/manual_test_elongate.yaml")
+	expectedTemplate, _ := ioutil.ReadFile("./test_resources/manual_test_correctlong.yaml")
+	fixed, _ := FixFunctions(rawTemplate, &sink, "correctlong")
+	expected, _ := parseFileIntoLines(expectedTemplate, &sink)
+	actual, _ := parseFileIntoLines(fixed, &sink)
+
+	if string(actual[len(actual)-1]) == "" {
+		actual = actual[:(len(actual) - 1)]
+	}
 
 	assert.Equal(t, expected, actual, "MSG")
 }

--- a/intrinsicsolver/preprocessed.yml
+++ b/intrinsicsolver/preprocessed.yml
@@ -1,7 +1,0 @@
-Key: 
-  Fn::Equals:
-  - "value_1"
-  - Fn::FindInMap:
-      - MapName
-      - TopLevelKey
-      - SecondLevelKey

--- a/intrinsicsolver/test_resources/manual_test_correctlong.yaml
+++ b/intrinsicsolver/test_resources/manual_test_correctlong.yaml
@@ -1,0 +1,1 @@
+Key: { "Fn::Equals": [ value_1, "Fn::FindInMap": [ MapName, "Ref": TopLevelKeyRef, SecondLevelKey ] ]}

--- a/intrinsicsolver/test_resources/manual_test_elongate.yaml
+++ b/intrinsicsolver/test_resources/manual_test_elongate.yaml
@@ -1,0 +1,1 @@
+Key: "Fn::Equals": [ value_1, "Fn::FindInMap": [ MapName, "Ref": TopLevelKeyRef, SecondLevelKey ] ]

--- a/intrinsicsolver/test_resources/test_elongate.yaml
+++ b/intrinsicsolver/test_resources/test_elongate.yaml
@@ -1,0 +1,1 @@
+Key: !Equals [ value_1, !FindInMap [ MapName, !Ref TopLevelKeyRef, SecondLevelKey ] ]

--- a/offlinevalidator/offlinevalidator.go
+++ b/offlinevalidator/offlinevalidator.go
@@ -145,7 +145,7 @@ func parseYAML(templateFile []byte, refTemplate template.Template, logger *logge
 		return template, err
 	}
 
-	preprocessed, preprocessingError := intrinsicsolver.FixFunctions(templateFile, logger)
+	preprocessed, preprocessingError := intrinsicsolver.FixFunctions(templateFile, logger, "multiline")
 	if preprocessingError != nil {
 		logger.Error(preprocessingError.Error())
 	}


### PR DESCRIPTION
1. Expanded `FixFunctions` function to deal with various issues by adding additional argument called `mode`.
2. Fixing multi-line maps was rewritten to the mode `multiline`.
3. Added mode `elongate` to change from short to long function names.
4. This unfortunately doesn't solve the issue of file being parsable. Or it does in most ideal case: YAML being truly YAML-ishly indented. YAML short one-line notation is breaking the parsing.
5. Added mode `correctlong` to fix above-mentioned issue. The preprocessing is not producing fully valid YAML but the one that is well parsing into JSON (so the checking if input is a valid YAML is held before preprocessing).