### PR TITLE
JSON parser now detects syntax errors and writes their position in the malformed file

### DIFF
--- a/offlinevalidator/offlinevalidator.go
+++ b/offlinevalidator/offlinevalidator.go
@@ -215,11 +215,14 @@ func parseJSON(templateFile []byte, refTemplate template.Template, logger *logge
 
 	err = json.Unmarshal(templateFile, &refTemplate)
 	if err != nil {
-		syntaxError, ok := err.(*json.SyntaxError)
-		if ok {
-			offset := int(syntaxError.Offset)
-			line, character := lineAndCharacter(string(templateFile), offset)
+		if syntaxError, isSyntaxError := err.(*json.SyntaxError); isSyntaxError {
+			syntaxOffset := int(syntaxError.Offset)
+			line, character := lineAndCharacter(string(templateFile), syntaxOffset)
 			logger.Error("Syntax error at line " + strconv.Itoa(line) + ", column " + strconv.Itoa(character))
+		} else if typeError, isTypeError := err.(*json.UnmarshalTypeError); isTypeError {
+			typeOffset := int(typeError.Offset)
+			line, character := lineAndCharacter(string(templateFile), typeOffset)
+			logger.Error("Type error at line " + strconv.Itoa(line) + ", column " + strconv.Itoa(character))
 		}
 		return template, err
 	}


### PR DESCRIPTION
As the @amamla noticed, the built-in Go library for unmarshalling the JSON is storing the offset of the malformed file part and we have to perform some excavation. Simple moving the function `lineAndCharacter` from the package `parsers` to the body of `offlinevalidator.go` and referencing to it through the `json.Unmarshal` solves the issue.

For example, this JSON:

```
{
  "Mappings" : {
    "RegionMap" : {
      "us-east-1" : { "32" : "ami-6411e20d", "64" : "ami-7a11e213" },
      "us-west-1" : { "32" : "ami-c9c7978c", "64" : "ami-cfc7978a" },
      "eu-west-1" : { "32" : "ami-37c2f643", "64" : "ami-31c2f645" },
      "ap-southeast-1" : { "32" : "ami-66f28c34", "64" : "ami-60f28c32" },
      "ap-northeast-1" : { "32" : "ami-9c03a89d", "64" : "ami-a003a8a1" }
    }
  },

  "Resources" : {
    "myEC2Instance"  {
      "Type" : "AWS::EC2::Instance",
      "Properties" : {
        "ImageId" : { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "32"]},
        "InstanceType" : "m1.small"
      }
    }
  }
}
```

Would output the following ERROR:

```
ERROR: Syntax error at line 13, column 22
ERROR: invalid character '{' after object key
ERROR: Template is invalid!
```

This solves the #37.
