### PR TITLE
Updated DEPENDENCIES.md

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -2,7 +2,7 @@
 
 ## MIT
 
-- https://github.com/alecthomas/kingpin
+- gopkg.in/alecthomas/kingpin.v2
   - Command-line parser. It is type-safe and allows to have short version of commands (e.g. `--config`, `-c`).
 - https://github.com/ghodss/yaml
   - *Go* lacks of YAML support out of the box, so we need this one.
@@ -19,3 +19,5 @@
   - AWS API.
 - https://github.com/go-ini/ini
   - For handling AWS credential files.
+- https://github.com/awslabs/goformation
+  - Library for working with AWS CloudFormation templates (capable of resolving the intrinsic functions).

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -2,7 +2,7 @@
 
 ## MIT
 
-- https://gopkg.in/alecthomas/kingpin.v2
+- https://github.com/alecthomas/kingpin
   - Command-line parser. It is type-safe and allows to have short version of commands (e.g. `--config`, `-c`).
 - https://github.com/ghodss/yaml
   - *Go* lacks of YAML support out of the box, so we need this one.
@@ -12,7 +12,6 @@
   - Library for decoding generic map to go structures. We need this one for type-aware validators implementation.
 - https://github.com/stretchr/testify
   - Test framework and assertions.
-  
 
 ## Apache 2.0
 
@@ -20,3 +19,5 @@
   - AWS API.
 - https://github.com/go-ini/ini
   - For handling AWS credential files.
+- https://github.com/awslabs/goformation
+  - Library for working with AWS CloudFormation templates (capable of resolving the intrinsic functions).

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -2,7 +2,7 @@
 
 ## MIT
 
-- gopkg.in/alecthomas/kingpin.v2
+- https://gopkg.in/alecthomas/kingpin.v2
   - Command-line parser. It is type-safe and allows to have short version of commands (e.g. `--config`, `-c`).
 - https://github.com/ghodss/yaml
   - *Go* lacks of YAML support out of the box, so we need this one.
@@ -12,6 +12,7 @@
   - Library for decoding generic map to go structures. We need this one for type-aware validators implementation.
 - https://github.com/stretchr/testify
   - Test framework and assertions.
+  
 
 ## Apache 2.0
 
@@ -19,5 +20,3 @@
   - AWS API.
 - https://github.com/go-ini/ini
   - For handling AWS credential files.
-- https://github.com/awslabs/goformation
-  - Library for working with AWS CloudFormation templates (capable of resolving the intrinsic functions).


### PR DESCRIPTION
As we are importing the `gopkg.in/alecthomas/kingpin.v2` (not `https://github.com/alecthomas/kingpin`), I've changed the link.
Also added the `goformation` reference.